### PR TITLE
design/fe/detail: 반응형 사진 간격 수정

### DIFF
--- a/client/src/components/DetailForm.js
+++ b/client/src/components/DetailForm.js
@@ -31,6 +31,7 @@ const SDetailWrap = styled.div`
   @media screen and (max-width: 1100px) {
     flex-direction: column;
     align-items: center;
+    gap: 0px;
   }
 `;
 


### PR DESCRIPTION
### 작업한 내용
- 상세 조회 페이지의 반응형 레이아웃에서 제목과 사진 간격이 너무 넓은 문제 수정

### 보충할 내용
- 댓글 영역 디자인 detail 페이지와 통일성있게 바꾸기
