### PR TITLE
fix/fe/comment

### DIFF
--- a/client/src/components/Comment.js
+++ b/client/src/components/Comment.js
@@ -6,20 +6,31 @@ import { prettyDate } from '../util/dateparse';
 import { useNavigate } from 'react-router-dom';
 
 const SCommentForm = styled.div`
-  margin: 30px 0;
+  margin: 30px auto;
+  padding: 0px 150px 0px 130px;
+  max-width: 1280px;
+
+  @media screen and (max-width: 1100px) {
+    padding: 0px 24px;
+  }
 `;
+
+const SCommentsInfo = styled.h2`
+  font-size: 1.3rem;
+`;
+
 const SInputContainer = styled.div`
   display: flex;
-  justify-content: center;
-  margin: 30px 0;
+  justify-content: space-between;
+  margin: 30px 0px 40px 0px;
   .InputComment {
-    width: 50%;
-    height: 40px;
+    width: 100%;
+    height: 60px;
     border: 1px solid #aaaaaa;
     border-radius: 5px;
     padding-left: 10px;
   }
-  .SunmbitComment {
+  .SubmitComment {
     margin-left: 30px;
     width: 100px;
     color: #ffffff;
@@ -28,24 +39,21 @@ const SInputContainer = styled.div`
     background-color: #bb2649;
   }
 `;
+
 const SCommentContainer = styled.div`
   color: #212529;
-  display: flex;
-  flex-direction: column;
   padding-bottom: 24px;
-  margin: 0 20%;
 `;
 
 const SUserContainer = styled.div`
   display: flex;
   align-items: center;
-  margin-bottom: 24px;
+  /* margin-bottom: 24px; */
   img {
-    margin: 0;
+    margin: 0px 10px 0px 5px;
     width: 35px;
     height: 35px;
     border-radius: 50%;
-    margin-right: 10px;
   }
   .userName {
     font-size: 16px;
@@ -61,6 +69,7 @@ const SUserContainer = styled.div`
     }
   }
 `;
+
 const SUserComment = styled.div`
   .content {
     width: 100%;
@@ -99,17 +108,17 @@ const SUserComment = styled.div`
     }
   }
 `;
+
 const SCommentWrap = styled.div`
   border-bottom: 1px solid #ececec;
-  margin: 10px 0;
+  margin: 20px 0;
+  padding-bottom: 10px;
 `;
 
 const Comment = ({ endpoint, comments, id }) => {
   const [content, setContent] = useState('');
   const [contentForm, setContentForm] = useState('');
   const navigate = useNavigate();
-
-  // const commentMap = page === 'share' ? borrowComment : reqComment;
 
   // 해당하는 유저에게만 댓글을 수정하고 삭제하는 권한주기
   const currentUser = sessionStorage.getItem('displayName');
@@ -259,6 +268,7 @@ const Comment = ({ endpoint, comments, id }) => {
   };
   return (
     <SCommentForm>
+      <SCommentsInfo>댓글 {comments.length}</SCommentsInfo>
       <SInputContainer>
         <input
           type="text"
@@ -266,11 +276,7 @@ const Comment = ({ endpoint, comments, id }) => {
           placeholder="댓글을 남겨보세요"
           onChange={handleChangeContent}
         />
-        <button
-          className="SunmbitComment"
-          type="sumbit"
-          onClick={commentSubmit}
-        >
+        <button className="SubmitComment" type="sumbit" onClick={commentSubmit}>
           등록
         </button>
       </SInputContainer>

--- a/client/src/components/DetailForm.js
+++ b/client/src/components/DetailForm.js
@@ -2,6 +2,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import ToggleSwitch from './ToggleSwitch';
 import ShareStatus from './ShareStatus';
+import Comment from './Comment';
 import instanceAxios from '../reissue/InstanceAxios';
 import { prettyDate } from '../util/dateparse';
 import { ReactComponent as KakaoFill } from '../image/kakaofill.svg';
@@ -183,7 +184,7 @@ const SContact = styled.div`
   }
 `;
 
-const DetailForm = ({ data, endpoint, id }) => {
+const DetailForm = ({ data, endpoint, id, comments }) => {
   const navigate = useNavigate();
 
   // 자기가 쓴 글이 아니면 수정, 삭제 버튼이 안 보여야 함
@@ -306,6 +307,7 @@ const DetailForm = ({ data, endpoint, id }) => {
           </SRightSide>
         </SDetailWrap>
       </div>
+      <Comment endpoint={endpoint} comments={comments} id={id} />
     </SDetailLayout>
   );
 };

--- a/client/src/page/CommonDetail.js
+++ b/client/src/page/CommonDetail.js
@@ -3,7 +3,6 @@ import { useState, useEffect } from 'react';
 import axios from 'axios';
 import DetailForm from '../components/DetailForm';
 import Swal from 'sweetalert2';
-import Comment from '../components/Comment';
 
 const CommonDetail = ({ endpoint }) => {
   const { id } = useParams();
@@ -38,8 +37,7 @@ const CommonDetail = ({ endpoint }) => {
 
   return (
     <>
-      <DetailForm data={data} endpoint={endpoint} id={id} />
-      <Comment endpoint={endpoint} comments={comment} id={id} />
+      <DetailForm data={data} endpoint={endpoint} id={id} comments={comment} />
     </>
   );
 };


### PR DESCRIPTION
### 작업한 내용
- 댓글 마크업이 DetailForm의 DOM tree에서 분리되어있던 문제 수정

[작업 전]
<img width="642" alt="스크린샷 2023-02-16 오후 11 57 31" src="https://user-images.githubusercontent.com/78579776/219414021-d041193e-4521-4f6d-809b-26b0c1ff2294.png">

[작업 후]
<img width="640" alt="스크린샷 2023-02-17 오전 12 26 54" src="https://user-images.githubusercontent.com/78579776/219414087-94430f31-48c3-4142-abd0-defb45dcc4f5.png">

- 댓글 영역 디자인 DetailForm과 통일성 있게 수정
- 댓글 개수 보여주는 영역 추가
<img width="1097" alt="스크린샷 2023-02-17 오전 12 34 52" src="https://user-images.githubusercontent.com/78579776/222041076-33684f2f-2a96-4fa9-b219-7bacdba8092b.png">

### 보충할 내용
- 
