### PR TITLE
fix/fe/crossBrowsing: 사파리에서 맨 밑으로 스크롤 시 헤더 내부 콘텐츠가 사라지던 문제 수정

### DIFF
--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -23,7 +23,7 @@ const StyledHeader = styled.header`
 const SHeaderLogo = styled.a`
   display: flex;
   align-items: center;
-  position: fixed;
+  position: absolute;
   left: 3%;
   .logo {
     fill: #bb2649;
@@ -42,7 +42,7 @@ const SNavContainer = styled.ol`
   flex-direction: row;
   text-align: center;
   padding: 0;
-  position: fixed;
+  position: absolute;
   left: 20%;
   .olItem {
     margin: 5px 33px;
@@ -118,7 +118,7 @@ const SLoginBtn = styled.button`
   color: #bb2649;
   border: 1px solid #bb2649;
   border-radius: 20px;
-  position: fixed;
+  position: absolute;
   right: 3%;
   :hover {
     color: #ffffff;


### PR DESCRIPTION
### 작업한 내용
- 사파리에서 맨 밑으로 스크롤 시 헤더 내부 콘텐츠가 사라져버리는 문제 수정
- `position: fixed;`를 `position: absolute;`로 바꾸어 해결함

### 보충할 내용
- 홈 로고에 지정된 `href`를 `navigate()`로 수정하기 (`href`를 쓰면 전체 페이지가 다시 로드됨. SPA의 의미가 사라짐)
