### PR TITLE
fix/fe/logoNavigate: 로고 클릭 href를 navigate로 수정

### DIFF
--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -20,7 +20,7 @@ const StyledHeader = styled.header`
   z-index: 2;
 `;
 
-const SHeaderLogo = styled.a`
+const SHeaderLogo = styled.div`
   display: flex;
   align-items: center;
   position: absolute;
@@ -33,6 +33,9 @@ const SHeaderLogo = styled.a`
       font-size: 15px;
       width: 140px;
     }
+  }
+  &:hover {
+    cursor: pointer;
   }
 `;
 
@@ -217,7 +220,7 @@ const Header = () => {
 
   return (
     <StyledHeader>
-      <SHeaderLogo href="/">
+      <SHeaderLogo onClick={() => navigate('/')}>
         <Logo className="logo" />
       </SHeaderLogo>
       <SNavContainer>


### PR DESCRIPTION
### 작업한 내용
- 헤더 로고 클릭에 href가 지정되어 페이지 전체가 새로고침되던 부분 수정

### 보충할 내용
- 
