### PR TITLE
fix/fe/loading: 화면 전체를 차지하지 않도록 수정

### DIFF
--- a/client/src/components/Loading.js
+++ b/client/src/components/Loading.js
@@ -2,16 +2,14 @@ import styled from 'styled-components';
 import Spinner from '../image/spinner.gif';
 
 const SBackground = styled.div`
-  position: absolute;
-  width: 100vw;
-  height: 100vh;
-  top: 0;
-  left: 0;
+  width: inherit;
+  height: 40vh;
   background: #ffffff;
   z-index: 999;
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: 18px 0px;
 `;
 
 const Loading = () => {


### PR DESCRIPTION
### 작업한 내용
- loading 컴포넌트가 화면 전체를 차지하여 페이지 전환 시마다 깜빡임이 발생했음.
- loading 컴포넌트가 화면 전체가 아닌 리스트 영역만큼만 차지하도록 수정

### 보충할 내용
- 
