### PR TITLE
refactor/fe/alert: sweetAlert 모듈 파일로 분리

### DIFF
--- a/client/src/components/common/Alert.js
+++ b/client/src/components/common/Alert.js
@@ -1,0 +1,36 @@
+import Swal from 'sweetalert2';
+
+export const showNormalAlert = (message) => {
+  Swal.fire(message);
+};
+
+export const showWarningAlert = (title, message) => {
+  Swal.fire(title, message, 'warning');
+};
+
+export const showSuccessAlert = (title, message) => {
+  Swal.fire(title, message, 'success');
+};
+
+export const showFailedToFetch = () => {
+  Swal.fire('데이터 로딩 실패', '데이터 로딩에 실패했습니다.', 'warning');
+};
+
+export const showRequireLogin = () => {
+  Swal.fire(
+    '로그인이 필요한 서비스입니다',
+    '로그인 후 이용해주세요',
+    'warning'
+  );
+};
+
+export const showConfirmAlert = (options) => {
+  return Swal.fire({
+    icon: 'warning',
+    showCancelButton: true,
+    confirmButtonColor: '#bb2649',
+    confirmButtonText: '확인',
+    cancelButtonText: '취소',
+    ...options,
+  });
+};

--- a/client/src/components/common/Comment.js
+++ b/client/src/components/common/Comment.js
@@ -1,9 +1,15 @@
 import styled from 'styled-components';
 import instanceAxios from '../../util/InstanceAxios';
-import Swal from 'sweetalert2';
 import { useState } from 'react';
 import { prettyDate } from '../../util/dateparse';
 import { useNavigate } from 'react-router-dom';
+import {
+  showNormalAlert,
+  showWarningAlert,
+  showSuccessAlert,
+  showRequireLogin,
+  showConfirmAlert,
+} from './Alert';
 
 const SCommentForm = styled.div`
   margin: 30px auto;
@@ -128,11 +134,7 @@ const Comment = ({ endpoint, comments, id }) => {
     setContent(e.target.value);
     const text_length = e.target.value.length;
     if (text_length > 60) {
-      Swal.fire(
-        '글자 수 초과',
-        '댓글은 60자 이상 작성 할 수 없습니다',
-        'warning'
-      );
+      showWarningAlert('글자 수 초과', '댓글은 60자 이상 작성할 수 없습니다.');
     }
   };
 
@@ -155,33 +157,20 @@ const Comment = ({ endpoint, comments, id }) => {
           .then((res) => {
             setContent(res.data.data.content);
             window.location.reload();
-            Swal.fire(
-              '댓글 등록',
-              '정상적으로 댓글이 등록되었습니다',
-              'success'
-            );
+            showSuccessAlert('댓글 등록', '댓글이 정상적으로 등록되었습니다');
           })
           .catch((err) => {
-            Swal.fire(
-              '댓글 등록 실패',
-              '댓글등록이 이루어지지 않았습니다.',
-              'warning'
-            );
+            showWarningAlert('댓글 등록 실패', '댓글 등록에 실패했습니다');
             console.error(err);
           });
       } else {
-        Swal.fire(
-          '내용을 입력하십시오',
-          '최소 1글자 이상 작성해주세요',
-          'warning'
+        showWarningAlert(
+          '내용을 입력하세요',
+          '최소 1글자 이상 작성해야 합니다'
         );
       }
     } else {
-      Swal.fire(
-        '로그인이 필요한 서비스입니다',
-        '로그인 후 이용해주세요.',
-        'warning'
-      );
+      showRequireLogin();
     }
   };
 
@@ -196,51 +185,29 @@ const Comment = ({ endpoint, comments, id }) => {
           window.location.reload();
         })
         .catch(() => {
-          Swal.fire(
-            '댓글수정 실패',
-            '댓글수정이 이루어지지 않았습니다.',
-            'warning'
-          );
+          showWarningAlert('댓글 수정 실패', '댓글 수정에 실패했습니다');
         });
     } else {
       console.error('err');
-      Swal.fire(
-        '내용을 입력하십시오',
-        '최소 1글자 이상 작성해주세요',
-        'warning'
-      );
+      showWarningAlert('내용을 입력하세요', '최소 1글자 이상 작성해야 합니다');
     }
   };
 
   //댓글 삭제
   const handleClickDeleteComment = (commentId) => {
-    Swal.fire({
+    showConfirmAlert({
       title: '작성을 취소하시겠습니까?',
       text: '작성 중인 내용은 저장되지 않습니다',
-      icon: 'warning',
-      showCancelButton: true,
-      confirmButtonColor: '#bb2649',
-      confirmButtonText: '확인',
-      cancelButtonText: '취소',
-      // reverseButtons: true, //버튼 순서 거꾸로
     }).then((res) => {
       if (res.isConfirmed) {
         instanceAxios
           .delete(`/v1/${endpoint}/comments/${commentId}`)
           .then(() => {
             window.location.reload();
-            Swal.fire(
-              '댓글 삭제 성공',
-              '정상적으로 댓글이 삭제되었습니다',
-              'success'
-            );
+            showNormalAlert('댓글이 정상적으로 삭제되었습니다.');
           })
           .catch(() => {
-            Swal.fire(
-              '댓글 삭제 실패',
-              '댓글삭제가 정상적으로 이루어지지 않았습니다.',
-              'warning'
-            );
+            showNormalAlert('댓글 삭제에 실패했습니다.');
           });
       }
     });
@@ -249,23 +216,7 @@ const Comment = ({ endpoint, comments, id }) => {
   const handleClickCancelModify = () => {
     setContentForm('');
   };
-  //수정 취소 확인 함수
-  const handleCancel = () => {
-    Swal.fire({
-      title: '작성을 취소하시겠습니까?',
-      text: '작성 중인 내용은 저장되지 않습니다',
-      icon: 'warning',
-      showCancelButton: true,
-      confirmButtonColor: '#bb2649',
-      confirmButtonText: '확인',
-      cancelButtonText: '취소',
-      // reverseButtons: true, //버튼 순서 거꾸로
-    }).then((res) => {
-      if (res.isConfirmed) {
-        navigate(-1);
-      }
-    });
-  };
+
   return (
     <SCommentForm>
       <SCommentsInfo>댓글 {comments.length}</SCommentsInfo>

--- a/client/src/components/common/DetailForm.js
+++ b/client/src/components/common/DetailForm.js
@@ -7,7 +7,7 @@ import instanceAxios from '../../util/InstanceAxios';
 import { prettyDate } from '../../util/dateparse';
 import { ReactComponent as KakaoFill } from '../../images/kakaofill.svg';
 import { ReactComponent as Eye } from '../../images/eye.svg';
-import Swal from 'sweetalert2';
+import { showNormalAlert, showConfirmAlert } from './Alert';
 
 const SDetailLayout = styled.main`
   padding: 24px;
@@ -196,23 +196,18 @@ const DetailForm = ({ data, endpoint, id, comments }) => {
   // 삭제 버튼 핸들러
   const handleDelete = () => {
     // 서버에 삭제 요청 보내기 (instanceAxios 쓰기)
-    Swal.fire({
+    showConfirmAlert({
       title: '정말로 삭제하시겠습니까?',
-      icon: 'warning',
-      showCancelButton: true,
-      confirmButtonColor: '#bb2649',
-      confirmButtonText: '확인',
-      cancelButtonText: '취소',
     }).then((res) => {
       if (res.isConfirmed) {
         instanceAxios
           .delete(`v1/${endpoint}/${id}`)
           .then(() => {
-            Swal.fire('글이 삭제되었습니다.');
+            showNormalAlert('글이 삭제되었습니다');
             navigate(-1);
           })
           .catch((err) => {
-            Swal.fire('삭제에 실패했습니다');
+            showNormalAlert('글 삭제에 실패했습니다');
             console.error(err);
           });
       }

--- a/client/src/components/rate/RateComment.js
+++ b/client/src/components/rate/RateComment.js
@@ -5,6 +5,11 @@ import { ReactComponent as BookStar } from '../../images/bookStar.svg';
 import instanceAxios from '../../util/InstanceAxios';
 import Swal from 'sweetalert2';
 import { prettyDate } from '../../util/dateparse';
+import {
+  showNormalAlert,
+  showWarningAlert,
+  showConfirmAlert,
+} from '../common/Alert.js';
 
 const SCommentWrap = styled.div`
   margin: 0px 10%;
@@ -115,9 +120,10 @@ const RateComment = ({ data }) => {
         content: editInput,
       })
       .then(() => {
-        Swal.fire({
+        showConfirmAlert({
           title: '평점이 정상적으로 수정되었습니다.',
           icon: 'success',
+          showCancelButton: false,
           confirmButtonText: '확인',
         }).then((res) => {
           if (res.isConfirmed) {
@@ -127,7 +133,7 @@ const RateComment = ({ data }) => {
       })
       .catch((err) => {
         console.log(err);
-        Swal.fire('수정 실패', '평점 수정에 실패했습니다.', 'warning');
+        showWarningAlert('평점 수정 실패', '평점 수정에 실패했습니다');
       });
   };
 
@@ -137,22 +143,18 @@ const RateComment = ({ data }) => {
 
   const handleDeleteRate = (rateId) => {
     // 삭제하기 전에 한 번 물어보기
-    Swal.fire({
+    showConfirmAlert({
       title: '평점을 삭제하시겠습니까?',
-      icon: 'warning',
-      showCancelButton: true,
-      confirmButtonColor: '#bb2649',
-      confirmButtonText: '확인',
-      cancelButtonText: '취소',
     }).then((res) => {
       if (res.isConfirmed) {
         instanceAxios.delete(`v1/rates/${rateId}`).then(() => {
-          Swal.fire('평점이 삭제되었습니다');
+          showNormalAlert('평점이 삭제되었습니다');
           window.location.reload();
         });
       }
     });
   };
+
   return (
     <>
       {data && (

--- a/client/src/components/rate/RateModal.js
+++ b/client/src/components/rate/RateModal.js
@@ -1,8 +1,8 @@
 import styled from 'styled-components';
-import Swal from 'sweetalert2';
 import { useState } from 'react';
 import instanceAxios from '../../util/InstanceAxios';
 import { RateStar } from './RateStar';
+import { showWarningAlert, showRequireLogin } from '../common/Alert';
 
 const SModalBackground = styled.div`
   position: fixed;
@@ -83,7 +83,10 @@ const RateModal = ({ isModalOpen, handleCloseModal, data }) => {
     const sessionAccessToken = sessionStorage.getItem('accessToken');
     if (sessionAccessToken) {
       if (content.length === 0) {
-        Swal.fire('평점 등록 실패', '1글자 이상 작성하셔야 합니다.', 'warning');
+        showWarningAlert(
+          '내용을 입력하세요',
+          '최소 1글자 이상 작성해야 합니다'
+        );
       } else {
         instanceAxios
           .post(
@@ -99,20 +102,15 @@ const RateModal = ({ isModalOpen, handleCloseModal, data }) => {
           })
           .catch((err) => {
             console.error(err);
-            Swal.fire(
-              '이미 평점이 등록되었습니다.',
-              '평점은 한 번만 등록할 수 있습니다.',
-              'warning'
+            showWarningAlert(
+              '이미 등록한 평점이 존재합니다',
+              '평점은 한 번만 등록할 수 있습니다'
             );
             handleCloseModal();
           });
       }
     } else {
-      Swal.fire(
-        '로그인이 필요한 서비스입니다',
-        '로그인 후 이용해주세요.',
-        'warning'
-      );
+      showRequireLogin();
     }
   };
 

--- a/client/src/components/request/ReqForm.js
+++ b/client/src/components/request/ReqForm.js
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import BookAddModal from '../common/BookAddModal';
-import Swal from 'sweetalert2';
+import { showConfirmAlert } from '../common/Alert';
 
 const StyledReqForm = styled.div`
   .title {
@@ -125,14 +125,9 @@ const ReqForm = (props) => {
   };
 
   const goBack = () => {
-    Swal.fire({
+    showConfirmAlert({
       title: '작성을 취소하시겠습니까?',
       text: '작성 중인 내용은 저장되지 않습니다',
-      icon: 'warning',
-      showCancelButton: true,
-      confirmButtonColor: '#bb2649',
-      confirmButtonText: '확인',
-      cancelButtonText: '취소',
     }).then((res) => {
       if (res.isConfirmed) {
         navigate(-1);

--- a/client/src/components/share/ShareForm.js
+++ b/client/src/components/share/ShareForm.js
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import BookAddModal from '../common/BookAddModal';
 import axios from 'axios';
-import Swal from 'sweetalert2';
+import { showWarningAlert, showConfirmAlert } from '../common/Alert';
 
 const StyledShareForm = styled.div`
   .title {
@@ -184,24 +184,18 @@ const ShareForm = (props) => {
       const fileSize = e.target.files[0].size;
 
       if (fileSize > maxSize) {
-        Swal.fire(
+        showWarningAlert(
           '책 표지 등록 실패',
-          '첨부 파일의 사이즈는 3MB 이내로 등록 가능합니다.',
-          'warning'
+          '첨부 파일의 사이즈는 3MB 이내로 등록 가능합니다'
         );
       }
     }
   };
 
   const goBack = () => {
-    Swal.fire({
+    showConfirmAlert({
       title: '작성을 취소하시겠습니까?',
       text: '작성 중인 내용은 저장되지 않습니다',
-      icon: 'warning',
-      showCancelButton: true,
-      confirmButtonColor: '#bb2649',
-      confirmButtonText: '확인',
-      cancelButtonText: '취소',
     }).then((res) => {
       if (res.isConfirmed) {
         navigate(-1);

--- a/client/src/components/share/ToggleSwitch.js
+++ b/client/src/components/share/ToggleSwitch.js
@@ -1,7 +1,7 @@
 import { useState } from 'react';
-import Swal from 'sweetalert2';
 import styled from 'styled-components';
 import instanceAxios from '../../util/InstanceAxios';
+import { showConfirmAlert } from '../common/Alert';
 
 const SLabel = styled.label`
   --width: 90px;
@@ -108,13 +108,8 @@ const ToggleSwitch = ({ id, status }) => {
   };
 
   const handleStatusChange = () => {
-    Swal.fire({
+    showConfirmAlert({
       title: '나눔 상태를 변경하시겠습니까?',
-      icon: 'warning',
-      showCancelButton: true,
-      confirmButtonColor: '#bb2649',
-      confirmButtonText: '확인',
-      cancelButtonText: '취소',
     }).then((res) => {
       if (res.isConfirmed) {
         handleToggleClick();

--- a/client/src/components/user/NicknameModal.js
+++ b/client/src/components/user/NicknameModal.js
@@ -1,9 +1,9 @@
 import styled from 'styled-components';
-import Swal from 'sweetalert2';
 import { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import instanceAxios from '../../util/InstanceAxios';
 import { setExisting } from '../../redux/slice/userSlice';
+import { showWarningAlert, showSuccessAlert } from '../common/Alert';
 
 const SModalBackground = styled.div`
   position: fixed;
@@ -134,10 +134,9 @@ const NicknameModal = ({ isModalOpen, handleCloseModal }) => {
         .then(() => {
           handleCloseModal();
           dispatch(setExisting({ displayName: nickname }));
-          Swal.fire(
-            '닉네임 설정이 완료되었습니다',
-            '북빌리지에 오신 것을 환영합니다!',
-            'success'
+          showSuccessAlert(
+            '닉네임 설정이 왼료되었습니다',
+            '북빌리지에 오신 것을 환영합니다!'
           );
         })
         .catch((err) => {
@@ -145,11 +144,7 @@ const NicknameModal = ({ isModalOpen, handleCloseModal }) => {
           if (err.response.status === 409) {
             setErrorMessage('이미 사용 중인 닉네임입니다.');
           } else {
-            Swal.fire(
-              '닉네임 등록 실패',
-              '닉네임 설정에 실패했습니다',
-              'warning'
-            );
+            showWarningAlert('닉네임 설정 실패', '닉네임 설정에 실패했습니다');
             console.error(err);
           }
         });

--- a/client/src/pages/CommonDetail.js
+++ b/client/src/pages/CommonDetail.js
@@ -3,6 +3,7 @@ import axios from 'axios';
 import DetailForm from '../components/common/DetailForm';
 import Swal from 'sweetalert2';
 import Loading from '../components/common/Loading';
+import { showFailedToFetch } from '../components/common/Alert';
 
 const CommonDetail = ({ endpoint, id }) => {
   const [data, setData] = useState({});
@@ -27,7 +28,7 @@ const CommonDetail = ({ endpoint, id }) => {
         setComment(comments);
       })
       .catch((err) => {
-        Swal.fire('데이터 로딩 실패', '데이터 로딩에 실패했습니다.', 'warning');
+        showFailedToFetch();
         console.error(err);
       });
   }, []);

--- a/client/src/pages/CommonList.js
+++ b/client/src/pages/CommonList.js
@@ -1,12 +1,12 @@
 import axios from 'axios';
 import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
-import Swal from 'sweetalert2';
 import styled from 'styled-components';
 import ListHigh from '../components/common/ListHigh';
 import BookList from '../components/common/BookList';
 import Paging from '../components/common/Paging';
 import Loading from '../components/common/Loading';
+import { showFailedToFetch } from '../components/common/Alert';
 
 const SListContainer = styled.div`
   margin: 0px 190px;
@@ -54,7 +54,7 @@ const CommonList = (props) => {
         setCount(0);
         setIsLoading(false);
         console.log(err);
-        Swal.fire('데이터 로딩 실패', '데이터 로딩에 실패했습니다.', 'warning');
+        showFailedToFetch();
       });
   }, [pathname]);
 
@@ -143,11 +143,7 @@ const CommonList = (props) => {
           setPage(1);
         })
         .catch((err) => {
-          Swal.fire(
-            '데이터 로딩 실패',
-            '데이터 로딩에 실패했습니다.',
-            'warning'
-          );
+          showFailedToFetch();
           console.error(err);
         });
     }

--- a/client/src/pages/MyPageEdit.js
+++ b/client/src/pages/MyPageEdit.js
@@ -4,6 +4,12 @@ import { useNavigate } from 'react-router-dom';
 import Swal from 'sweetalert2';
 import instanceAxios from '../util/InstanceAxios';
 import axios from 'axios';
+import {
+  showWarningAlert,
+  showSuccessAlert,
+  showFailedToFetch,
+  showConfirmAlert,
+} from '../components/common/Alert';
 
 const SWrapEdit = styled.div`
   display: flex;
@@ -230,15 +236,9 @@ const MyPageEdit = () => {
 
   //수정 취소 확인 함수
   const handleCancel = () => {
-    Swal.fire({
+    showConfirmAlert({
       title: '작성을 취소하시겠습니까?',
       text: '작성 중인 내용은 저장되지 않습니다',
-      icon: 'warning',
-      showCancelButton: true,
-      confirmButtonColor: '#bb2649',
-      confirmButtonText: '확인',
-      cancelButtonText: '취소',
-      // reverseButtons: true, //버튼 순서 거꾸로
     }).then((res) => {
       if (res.isConfirmed) {
         navigate(-1);
@@ -258,18 +258,13 @@ const MyPageEdit = () => {
       .then(() => {
         navigate('/mypage');
         window.location.reload();
-        Swal.fire(
-          '프로필 수정 완료.',
-          '프로필 수정이 정상적으로 이루어졌습니다.',
-          'success'
+        showSuccessAlert(
+          '프로필 수정 완료',
+          '프로필이 정상적으로 수정되었습니다'
         );
       })
       .catch((err) => {
-        Swal.fire(
-          '프로필 수정 실패',
-          '수정이 정상적으로 등록되지 않았습니다.',
-          'warning'
-        );
+        showWarningAlert('프로필 수정 실패', '프로필 수정에 실패했습니다');
         console.error(err);
       });
   };
@@ -286,12 +281,8 @@ const MyPageEdit = () => {
         setImgUrl(res.data.data.imgUrl);
       } catch (error) {
         console.error(error);
+        showFailedToFetch();
         navigate('/');
-        Swal.fire(
-          '죄송합니다',
-          '회원님의 정보를 가져오는데 실패했습니다.',
-          'warning'
-        );
       }
     };
     editData();
@@ -299,14 +290,10 @@ const MyPageEdit = () => {
 
   //회원탈퇴
   const handleClickQuit = () => {
-    Swal.fire({
+    showConfirmAlert({
       title: '회원탈퇴를 진행하시겠습니까?',
       text: '회원탈퇴 후 로그인이 불가하니 신중하게 생각해주세요.',
-      icon: 'warning',
-      showCancelButton: true, // cancel버튼 보이기. 기본은 원래 없음
-      confirmButtonColor: '#bb2649', // confrim 버튼 색깔 지정
-      confirmButtonText: '탈퇴', // confirm 버튼 텍스트 지정
-      cancelButtonText: '취소', // cancel 버튼 텍스트 지정
+      confirmButtonText: '탈퇴',
     }).then((res) => {
       if (res.isConfirmed) {
         // 만약 모달창에서 confirm 버튼을 눌렀다면
@@ -314,10 +301,9 @@ const MyPageEdit = () => {
           sessionStorage.clear();
           navigate('/');
           window.location.reload();
-          Swal.fire(
+          showSuccessAlert(
             '정상적으로 회원탈퇴가 처리되었습니다.',
-            '이용해주셔서 감사합니다',
-            'success'
+            '이용해주셔서 감사합니다'
           );
         });
       }

--- a/client/src/pages/RateAdd.js
+++ b/client/src/pages/RateAdd.js
@@ -5,6 +5,12 @@ import BookAddModal from '../components/common/BookAddModal';
 import instanceAxios from '../util/InstanceAxios';
 import { RateStar } from '../components/rate/RateStar';
 import Swal from 'sweetalert2';
+import {
+  showRequireLogin,
+  showSuccessAlert,
+  showConfirmAlert,
+  showWarningAlert,
+} from '../components/common/Alert';
 
 const StyledForm = styled.div`
   margin: 0px 190px;
@@ -136,25 +142,21 @@ const RateAdd = () => {
 
   const handleSubmit = () => {
     if (!accessToken) {
-      Swal.fire({
-        title: '로그인이 필요한 서비스입니다.',
-        text: '로그인 후 이용해주세요.',
-        icon: 'warning',
-      });
+      showRequireLogin();
       return;
     }
 
     // input 유효성 검사
     if (rating === 0) {
-      Swal.fire('등록 불가', '평점은 최소 1점 이상 등록 가능합니다', 'warning');
+      showWarningAlert('등록 불가', '평점은 최소 1점 이상 등록 가능합니다');
       return;
     }
     if (!bookTitle || bookTitle.length === 0) {
-      Swal.fire('등록 불가', '책 정보를 입력해주세요', 'warning');
+      showWarningAlert('등록 불가', '책 정보를 입력해주세요');
       return;
     }
     if (!content || content.length === 0) {
-      Swal.fire('등록 불가', '코멘트를 입력해주세요', 'warning');
+      showWarningAlert('등록 불가', '코멘트를 입력해주세요');
       return;
     }
 
@@ -169,25 +171,16 @@ const RateAdd = () => {
         }
       )
       .then(() => {
-        Swal.fire(
-          '평점 등록 완료',
-          '평점이 정상적으로 등록되었습니다.',
-          'success'
-        );
+        showSuccessAlert('평점 등록 완료', '평점이 정상적으로 등록되었습니다');
         navigate('/rateList');
       })
       .catch((err) => console.error(err));
   };
 
   const handleCancel = () => {
-    Swal.fire({
+    showConfirmAlert({
       title: '작성을 취소하시겠습니까?',
       text: '작성 중인 내용은 저장되지 않습니다',
-      icon: 'warning',
-      showCancelButton: true,
-      confirmButtonColor: '#bb2649',
-      confirmButtonText: '확인',
-      cancelButtonText: '취소',
     }).then((res) => {
       if (res.isConfirmed) {
         navigate(-1);

--- a/client/src/pages/RateDetail.js
+++ b/client/src/pages/RateDetail.js
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 import { ReactComponent as BookStar } from '../images/bookStar.svg';
 import RateModal from '../components/rate/RateModal';
 import RateComment from '../components/rate/RateComment';
-import Swal from 'sweetalert2';
+import { showFailedToFetch } from '../components/common/Alert';
 
 const SDetailLayout = styled.main`
   padding: 24px;
@@ -164,7 +164,7 @@ const RateDetail = () => {
         setRateComment(comments);
       })
       .catch((err) => {
-        Swal.fire('데이터 로딩 실패', '데이터 로딩에 실패했습니다.', 'warning');
+        showFailedToFetch();
         console.error(err);
       });
   }, []);

--- a/client/src/pages/ReqAdd.js
+++ b/client/src/pages/ReqAdd.js
@@ -4,6 +4,11 @@ import Swal from 'sweetalert2';
 import instanceAxios from '../util/InstanceAxios';
 import { useNavigate } from 'react-router-dom';
 import { checkTalkUrl } from '../util/checkTalkUrl';
+import {
+  showRequireLogin,
+  showWarningAlert,
+  showSuccessAlert,
+} from '../components/common/Alert';
 
 const ReqAdd = () => {
   const navigate = useNavigate();
@@ -26,19 +31,14 @@ const ReqAdd = () => {
   const handleClickSubmit = () => {
     const accessToken = sessionStorage.getItem('accessToken');
     if (!accessToken) {
-      Swal.fire(
-        '로그인이 필요한 서비스입니다',
-        '로그인 후 이용해주세요.',
-        'warning'
-      );
+      showRequireLogin();
       return;
     }
 
     if (!checkTalkUrl(talkUrl)) {
-      Swal.fire(
+      showWarningAlert(
         '오픈채팅 링크를 확인해주세요',
-        '링크에는 https:// 혹은 http://가 포함되어야 합니다.',
-        'warning'
+        '링크에는 https:// 혹은 http://가 포함되어야 합니다.'
       );
       return;
     }
@@ -54,15 +54,14 @@ const ReqAdd = () => {
         thumbnail,
       })
       .then((res) => {
-        Swal.fire(
-          '요청 글 등록 완료.',
-          '요청 글이 정상적으로 작성되었습니다.',
-          'success'
+        showSuccessAlert(
+          '요청글 등록 완료',
+          '요청글이 정상적으로 등록되었습니다'
         );
         navigate('/reqList');
       })
       .catch((err) => {
-        Swal.fire('요청글 작성 실패', '글 등록에 실패했습니다.', 'warning');
+        showWarningAlert('요청글 작성 실패', '글 등록에 실패했습니다');
       });
   };
 

--- a/client/src/pages/ReqEdit.js
+++ b/client/src/pages/ReqEdit.js
@@ -2,7 +2,7 @@ import ReqForm from '../components/request/ReqForm';
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import instanceAxios from '../util/InstanceAxios';
-import Swal from 'sweetalert2';
+import { showSuccessAlert, showWarningAlert } from '../components/common/Alert';
 
 const ReqEdit = () => {
   const navigate = useNavigate();
@@ -36,15 +36,14 @@ const ReqEdit = () => {
         thumbnail,
       })
       .then((res) => {
-        Swal.fire(
+        showSuccessAlert(
           '요청글 수정 완료',
-          '글이 정상적으로 수정되었습니다.',
-          'success'
+          '요청글이 정상적으로 수정되었습니다.'
         );
         navigate('/ReqList');
       })
       .catch((err) => {
-        Swal.fire('요청글 수정 실패', '글 수정에 실패했습니다.', 'warning');
+        showWarningAlert('요청글 수정 실패', '글 수정에 실패했습니다');
       });
   };
 

--- a/client/src/pages/ShareAdd.js
+++ b/client/src/pages/ShareAdd.js
@@ -1,9 +1,13 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import Swal from 'sweetalert2';
 import ShareForm from '../components/share/ShareForm';
 import instanceAxios from '../util/InstanceAxios';
 import { checkTalkUrl } from '../util/checkTalkUrl';
+import {
+  showRequireLogin,
+  showWarningAlert,
+  showSuccessAlert,
+} from '../components/common/Alert';
 
 const ShareAdd = () => {
   const navigate = useNavigate();
@@ -25,19 +29,14 @@ const ShareAdd = () => {
   const handleClickSubmit = () => {
     const accessToken = sessionStorage.getItem('accessToken');
     if (!accessToken) {
-      Swal.fire(
-        '로그인이 필요한 서비스입니다',
-        '로그인 후 이용해주세요.',
-        'warning'
-      );
+      showRequireLogin();
       return;
     }
 
     if (!checkTalkUrl(talkUrl)) {
-      Swal.fire(
+      showWarningAlert(
         '오픈채팅 링크를 확인해주세요',
-        '링크에는 https:// 혹은 http://가 포함되어야 합니다.',
-        'warning'
+        '링크에는 https:// 혹은 http://가 포함되어야 합니다.'
       );
       return;
     }
@@ -53,15 +52,14 @@ const ShareAdd = () => {
         thumbnail,
       })
       .then((res) => {
-        Swal.fire(
-          '나눔 글 등록 완료.',
-          '나눔 글이 정상적으로 작성되었습니다.',
-          'success'
+        showSuccessAlert(
+          '나눔글 등록 완료',
+          '나눔글이 정상적으로 등록되었습니다.'
         );
         navigate('/shareList');
       })
       .catch((err) => {
-        Swal.fire('나눔글 작성 실패', '글 등록에 실패했습니다.', 'warning');
+        showWarningAlert('나눔글 등록 실패', '나눔글 등록에 실패했습니다.');
       });
   };
 

--- a/client/src/pages/ShareEdit.js
+++ b/client/src/pages/ShareEdit.js
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import Swal from 'sweetalert2';
 import ShareForm from '../components/share/ShareForm';
 import instanceAxios from '../util/InstanceAxios';
+import { showSuccessAlert, showWarningAlert } from '../components/common/Alert';
 
 const ShareEdit = (onBookInfoChange) => {
   const navigate = useNavigate();
@@ -34,15 +35,14 @@ const ShareEdit = (onBookInfoChange) => {
         thumbnail,
       })
       .then((res) => {
-        Swal.fire(
+        showSuccessAlert(
           '나눔글 수정 완료',
-          '글 수정이 정상적으로 수정되었습니다.',
-          'success'
+          '나눔글이 정상적으로 수정되었습니다'
         );
         navigate('/shareList');
       })
       .catch((err) => {
-        Swal.fire('나눔글 수정 실패', '글 수정에 실패했습니다.', 'warning');
+        showWarningAlert('나눔글 수정 실패', '나눔글 수정에 실패했습니다');
       });
   };
 

--- a/client/src/util/InstanceAxios.js
+++ b/client/src/util/InstanceAxios.js
@@ -2,7 +2,7 @@
 import axios from 'axios';
 import jwtDecode from 'jwt-decode';
 import { getCookie, removeCookie } from './cookie';
-import Swal from 'sweetalert2';
+import { showWarningAlert } from '../components/common/Alert';
 
 //###1. axios에 특별한 설정을 하기 위해 axios.create 메소드를 이용해서 인스턴스를 만든다.
 const instanceAxios = axios.create({
@@ -61,11 +61,7 @@ instanceAxios.interceptors.request.use(
             })
             .catch((err) => {
               console.error(err);
-              Swal.fire(
-                '죄송합니다',
-                '로그아웃 후 다시 이용해주세요.',
-                'warning'
-              );
+              showWarningAlert('죄송합니다', '로그아웃 후 다시 이용해주세요.');
             });
         };
         token();


### PR DESCRIPTION
### 작업한 내용
- `sweetAlert` 호출 코드를 한 파일로 모음. 
- 18개 파일에 흩어져있던 56개의 반복적인 코드를 줄일 수 있었음.
- 한 알림창 형태가 세 파일 이상 반복될 경우에 함수 하나로 분리함.
  - `showNormalAlert`: 일반 알림
  - `showWarningAlert`: 경고 알림
  - `showSuccessAlert`: 성공 알림
  - `showFailedToFetch`: 데이터 로딩 실패
  - `showRequireLogin`: 로그인 필요 서비스
  - `showConfirmAlert`: 유저 확인/취소 상호작용에 따라 작업이 달라지는 경우

### 보충할 내용
- 
