### PR TITLE
refactor/fe/buttons: 버튼 한 컴포넌트 파일로 분리

### DIFF
--- a/client/src/components/common/BookAddModal.js
+++ b/client/src/components/common/BookAddModal.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import { useState, useEffect } from 'react';
 import BookSearch from '../../util/bookApi';
+import { Button } from './Button';
 
 const SModalBackground = styled.div`
   position: fixed;
@@ -54,6 +55,9 @@ const SModalBox = styled.div`
   box-sizing: border-box;
   padding: 5px;
   margin: 10px auto;
+  button {
+    margin-left: 10px;
+  }
   .inputBox {
     display: flex;
     align-items: flex-start;
@@ -64,8 +68,6 @@ const SModalBox = styled.div`
     font-size: 16px;
   }
   .search {
-    margin-left: 10px;
-    padding: 10px;
     border: 1px solid #bb2649;
     border-radius: 3px;
     color: #bb2649;
@@ -196,9 +198,7 @@ const BookAddModal = ({
                     value={text}
                     autoComplete="off"
                   />
-                  <button className="search" onClick={handleClickSearch}>
-                    검색
-                  </button>
+                  <Button text="검색" onClick={handleClickSearch} small />
                 </div>
                 <>
                   {bookList.map((book, idx) => (

--- a/client/src/components/common/Button.js
+++ b/client/src/components/common/Button.js
@@ -1,29 +1,38 @@
 import styled, { css } from 'styled-components';
 
-// 일반 버튼
+// 버튼 배경색 초기 설정: 빨간 배경
+const primary = css`
+  background-color: #bb2649;
+  color: #ffffff;
+`;
+
 const SButton = styled.button`
   width: 90px;
   height: 41px;
   padding: 10px;
   border: 1px solid #bb2649;
   border-radius: 5px;
-  color: #ffffff;
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: #bb2649;
+
+  /* 배경색 지정 */
+  ${(props) =>
+    props.primary
+      ? primary
+      : css`
+          background-color: #ffffff;
+          color: #bb2649;
+        `}
   ${(props) =>
     props.cancel
       ? css`
-          background-color: #ffffff;
-          color: #bb2649;
           margin-right: 5%;
         `
       : null}
   ${(props) =>
     props.comment
       ? css`
-          margin-left: 30px;
           width: 100px;
           height: 60px;
         `
@@ -31,10 +40,20 @@ const SButton = styled.button`
   ${(props) =>
     props.wide
       ? css`
-          margin-top: 20px;
           width: 300px;
           height: 35px;
           border-radius: 2.5px;
+        `
+      : null}
+  ${(props) =>
+    props.small
+      ? css`
+          width: fit-content;
+          border-radius: 3px;
+          :hover {
+            background-color: #bb2649;
+            color: #ffffff;
+          }
         `
       : null}
 `;
@@ -43,8 +62,8 @@ const SButton = styled.button`
 const SRegisterButton = styled(SButton)`
   background-color: #cf385b;
   border-radius: 3px;
-  box-shadow: inset 0 1px 0 hsla(0, 0%, 100%, 0.7);
   font-weight: 500;
+  box-shadow: inset 0 1px 0 hsla(0, 0%, 100%, 0.7);
 
   :hover {
     color: #ffffff;
@@ -57,13 +76,7 @@ const SRegisterButton = styled(SButton)`
       ? css`
           width: 100px;
         `
-      : css`
-          @media screen and (max-width: 1023px) {
-            width: 80px;
-            margin-right: 0;
-            font-size: 0.95rem;
-          }
-        `}
+      : null}
 `;
 
 export const Button = ({ text, onClick, ...props }) => {

--- a/client/src/components/common/Button.js
+++ b/client/src/components/common/Button.js
@@ -28,6 +28,15 @@ const SButton = styled.button`
           height: 60px;
         `
       : null}
+  ${(props) =>
+    props.wide
+      ? css`
+          margin-top: 20px;
+          width: 300px;
+          height: 35px;
+          border-radius: 2.5px;
+        `
+      : null}
 `;
 
 // 글 작성 페이지 접속 버튼 (나눔하기, 요청하기, 평점 책 등록하기)

--- a/client/src/components/common/Button.js
+++ b/client/src/components/common/Button.js
@@ -1,0 +1,74 @@
+import styled, { css } from 'styled-components';
+
+// 일반 버튼
+const SButton = styled.button`
+  width: 90px;
+  height: 41px;
+  padding: 10px;
+  border: 1px solid #bb2649;
+  border-radius: 5px;
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #bb2649;
+  ${(props) =>
+    props.cancel
+      ? css`
+          background-color: #ffffff;
+          color: #bb2649;
+          margin-right: 5%;
+        `
+      : null}
+  ${(props) =>
+    props.comment
+      ? css`
+          margin-left: 30px;
+          width: 100px;
+          height: 60px;
+        `
+      : null}
+`;
+
+// 글 작성 페이지 접속 버튼 (나눔하기, 요청하기, 평점 책 등록하기)
+const SRegisterButton = styled(SButton)`
+  background-color: #cf385b;
+  border-radius: 3px;
+  box-shadow: inset 0 1px 0 hsla(0, 0%, 100%, 0.7);
+  font-weight: 500;
+
+  :hover {
+    color: #ffffff;
+    background-color: #bb2649;
+    border: 1px solid #bb2649;
+  }
+
+  ${(props) =>
+    props.rate
+      ? css`
+          width: 100px;
+        `
+      : css`
+          @media screen and (max-width: 1023px) {
+            width: 80px;
+            margin-right: 0;
+            font-size: 0.95rem;
+          }
+        `}
+`;
+
+export const Button = ({ text, onClick, ...props }) => {
+  return (
+    <SButton onClick={onClick} {...props}>
+      {text}
+    </SButton>
+  );
+};
+
+export const RegisterButton = ({ text, onClick, ...props }) => {
+  return (
+    <SRegisterButton onClick={onClick} {...props}>
+      {text}
+    </SRegisterButton>
+  );
+};

--- a/client/src/components/common/Comment.js
+++ b/client/src/components/common/Comment.js
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import instanceAxios from '../../util/InstanceAxios';
 import { useState } from 'react';
 import { prettyDate } from '../../util/dateparse';
-import { useNavigate } from 'react-router-dom';
+import { Button } from './Button';
 import {
   showNormalAlert,
   showWarningAlert,
@@ -124,7 +124,6 @@ const SCommentWrap = styled.div`
 const Comment = ({ endpoint, comments, id }) => {
   const [content, setContent] = useState('');
   const [contentForm, setContentForm] = useState('');
-  const navigate = useNavigate();
 
   // 해당하는 유저에게만 댓글을 수정하고 삭제하는 권한주기
   const currentUser = sessionStorage.getItem('displayName');
@@ -145,9 +144,10 @@ const Comment = ({ endpoint, comments, id }) => {
   };
 
   //댓글 등록
-  const commentSubmit = () => {
+  const handleSubmit = () => {
     //로그인 회원만 이용가능한 서비스
     const sessionAccessToken = sessionStorage.getItem('accessToken');
+    // TODO: 리팩토링하기
     if (sessionAccessToken) {
       if (content) {
         instanceAxios
@@ -227,9 +227,7 @@ const Comment = ({ endpoint, comments, id }) => {
           placeholder="댓글을 남겨보세요"
           onChange={handleChangeContent}
         />
-        <button className="SubmitComment" type="sumbit" onClick={commentSubmit}>
-          등록
-        </button>
+        <Button text="등록" onClick={handleSubmit} comment />
       </SInputContainer>
       <SCommentContainer>
         {comments.map((comment) => {

--- a/client/src/components/common/Comment.js
+++ b/client/src/components/common/Comment.js
@@ -147,31 +147,29 @@ const Comment = ({ endpoint, comments, id }) => {
   const handleSubmit = () => {
     //로그인 회원만 이용가능한 서비스
     const sessionAccessToken = sessionStorage.getItem('accessToken');
-    // TODO: 리팩토링하기
-    if (sessionAccessToken) {
-      if (content) {
-        instanceAxios
-          .post(`/v1/${endpoint}/comments/${id}`, {
-            content,
-          })
-          .then((res) => {
-            setContent(res.data.data.content);
-            window.location.reload();
-            showSuccessAlert('댓글 등록', '댓글이 정상적으로 등록되었습니다');
-          })
-          .catch((err) => {
-            showWarningAlert('댓글 등록 실패', '댓글 등록에 실패했습니다');
-            console.error(err);
-          });
-      } else {
-        showWarningAlert(
-          '내용을 입력하세요',
-          '최소 1글자 이상 작성해야 합니다'
-        );
-      }
-    } else {
+
+    if (!sessionAccessToken) {
       showRequireLogin();
+      return;
     }
+    if (!content) {
+      showWarningAlert('내용을 입력하세요', '최소 1글자 이상 작성해야 합니다');
+      return;
+    }
+
+    instanceAxios
+      .post(`/v1/${endpoint}/comments/${id}`, {
+        content,
+      })
+      .then((res) => {
+        setContent(res.data.data.content);
+        window.location.reload();
+        showSuccessAlert('댓글 등록', '댓글이 정상적으로 등록되었습니다');
+      })
+      .catch((err) => {
+        showWarningAlert('댓글 등록 실패', '댓글 등록에 실패했습니다');
+        console.error(err);
+      });
   };
 
   //댓글 수정

--- a/client/src/components/common/Comment.js
+++ b/client/src/components/common/Comment.js
@@ -29,20 +29,12 @@ const SInputContainer = styled.div`
   display: flex;
   justify-content: space-between;
   margin: 30px 0px 40px 0px;
-  .InputComment {
+  .commentInput {
     width: 100%;
     height: 60px;
     border: 1px solid #aaaaaa;
     border-radius: 5px;
     padding-left: 10px;
-  }
-  .SubmitComment {
-    margin-left: 30px;
-    width: 100px;
-    color: #ffffff;
-    border: 1px solid #bb2649;
-    border-radius: 5px;
-    background-color: #bb2649;
   }
 `;
 
@@ -221,7 +213,7 @@ const Comment = ({ endpoint, comments, id }) => {
       <SInputContainer>
         <input
           type="text"
-          className="InputComment"
+          className="commentInput"
           placeholder="댓글을 남겨보세요"
           onChange={handleChangeContent}
         />

--- a/client/src/components/common/Comment.js
+++ b/client/src/components/common/Comment.js
@@ -36,6 +36,9 @@ const SInputContainer = styled.div`
     border-radius: 5px;
     padding-left: 10px;
   }
+  button {
+    margin-left: 20px;
+  }
 `;
 
 const SCommentContainer = styled.div`
@@ -46,7 +49,6 @@ const SCommentContainer = styled.div`
 const SUserContainer = styled.div`
   display: flex;
   align-items: center;
-  /* margin-bottom: 24px; */
   img {
     margin: 0px 10px 0px 5px;
     width: 35px;
@@ -217,7 +219,7 @@ const Comment = ({ endpoint, comments, id }) => {
           placeholder="댓글을 남겨보세요"
           onChange={handleChangeContent}
         />
-        <Button text="등록" onClick={handleSubmit} comment />
+        <Button text="등록" onClick={handleSubmit} comment primary />
       </SInputContainer>
       <SCommentContainer>
         {comments.map((comment) => {

--- a/client/src/components/common/DetailForm.js
+++ b/client/src/components/common/DetailForm.js
@@ -134,10 +134,8 @@ const SAuthorAndStatus = styled.div`
 const SBookInfo = styled.div`
   margin-top: 20px;
   margin-bottom: 40px;
-  /* border: 1px solid #bb2649; */
   background-color: #fffbeac2;
   border-radius: 5px;
-  /* border-bottom: 1px solid #aaaaaa; */
   padding: 24px 12px 5px 24px;
 
   h2 {

--- a/client/src/components/common/Header.js
+++ b/client/src/components/common/Header.js
@@ -146,18 +146,12 @@ const SLogout = styled.div`
   }
 `;
 
-const SLogoutBtn = styled.button`
-  width: 90px;
-  height: 33px;
-  font-size: 16px;
-  font-weight: 600;
+const SLogoutBtn = styled(SLoginBtn)`
   color: #ffffff;
   background-color: #bb2649;
   border: 1px solid #bb2649;
-  border-radius: 20px;
   :hover {
     color: #bb2649;
-    border: 1px solid #bb2649;
     background-color: #ffffff;
   }
 `;

--- a/client/src/components/common/ListHigh.js
+++ b/client/src/components/common/ListHigh.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import { ReactComponent as Search } from '../../images/SearchIcon.svg';
 import { useNavigate } from 'react-router-dom';
+import { RegisterButton } from './Button';
 
 const SShareTop = styled.div`
   display: flex;
@@ -95,33 +96,6 @@ const SShareTop = styled.div`
       font-size: 0.8rem;
     }
   }
-  .register {
-    width: 90px;
-    height: 38px;
-    padding: 10px;
-    border: 1px solid #bb2649;
-    border-radius: 3px;
-    color: #ffffff;
-    font-weight: 500;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background-color: #cf385b;
-    box-shadow: inset 0 1px 0 hsla(0, 0%, 100%, 0.7);
-
-    :hover {
-      color: #ffffff;
-      background-color: #bb2649;
-      border: 1px solid #bb2649;
-    }
-
-    @media screen and (max-width: 1023px) {
-      width: 80px;
-      height: 41px;
-      margin-right: 0;
-      font-size: 0.95rem;
-    }
-  }
 `;
 
 const ListHigh = ({
@@ -162,11 +136,10 @@ const ListHigh = ({
           />
           <Search className="search-icon" />
         </div>
-        <div>
-          <button className="register" onClick={() => navigate(path)}>
-            {route === 'share' ? '나눔하기' : '요청하기'}
-          </button>
-        </div>
+        <RegisterButton
+          text={route === 'share' ? '나눔하기' : '요청하기'}
+          onClick={() => navigate(path)}
+        />
       </div>
     </SShareTop>
   );

--- a/client/src/components/common/ListHigh.js
+++ b/client/src/components/common/ListHigh.js
@@ -96,6 +96,13 @@ const SShareTop = styled.div`
       font-size: 0.8rem;
     }
   }
+  button {
+    @media screen and (max-width: 1023px) {
+      width: 80px;
+      margin-right: 0;
+      font-size: 0.95rem;
+    }
+  }
 `;
 
 const ListHigh = ({
@@ -139,6 +146,7 @@ const ListHigh = ({
         <RegisterButton
           text={route === 'share' ? '나눔하기' : '요청하기'}
           onClick={() => navigate(path)}
+          primary
         />
       </div>
     </SShareTop>

--- a/client/src/components/rate/RateModal.js
+++ b/client/src/components/rate/RateModal.js
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import instanceAxios from '../../util/InstanceAxios';
 import { RateStar } from './RateStar';
 import { showWarningAlert, showRequireLogin } from '../common/Alert';
+import { Button } from '../common/Button';
 
 const SModalBackground = styled.div`
   position: fixed;
@@ -33,10 +34,12 @@ const SRateModal = styled.div`
     cursor: pointer;
   }
 `;
+
 const SRateInfo = styled.div`
   display: flex;
   flex-direction: column;
   margin: 0;
+  align-items: center;
   text-align: center;
   .rateExplain {
     margin-top: 40px;
@@ -46,15 +49,6 @@ const SRateInfo = styled.div`
     flex-direction: row;
     margin-bottom: 20px;
   }
-  .rateReviewBtn {
-    margin-top: 20px;
-    width: 300px;
-    height: 35px;
-    border: 1px solid #bb2649;
-    border-radius: 2.5px;
-    background-color: #bb2649;
-    color: #ffffff;
-  }
   .rateReviewTextBox {
     border-radius: 2.5px;
     padding: 10px;
@@ -62,12 +56,6 @@ const SRateInfo = styled.div`
     height: 100px;
     width: 300px;
   }
-`;
-const SLimitNumber = styled.div`
-  font-size: 10px !important;
-  text-align: left;
-  margin-left: 50px;
-  color: #bb2649 !important;
 `;
 
 const RateModal = ({ isModalOpen, handleCloseModal, data }) => {
@@ -78,8 +66,9 @@ const RateModal = ({ isModalOpen, handleCloseModal, data }) => {
     setContent(e.target.value);
   };
 
-  const handleClickRateSubmit = () => {
-    //로그인 회원만 이용가능한 서비스
+  const handleRateSubmit = () => {
+    // 로그인 회원만 이용가능한 서비스
+    // TODO: 로직 리팩토링
     const sessionAccessToken = sessionStorage.getItem('accessToken');
     if (sessionAccessToken) {
       if (content.length === 0) {
@@ -122,7 +111,6 @@ const RateModal = ({ isModalOpen, handleCloseModal, data }) => {
             <div className="close" onClick={handleCloseModal}>
               &times;
             </div>
-            {/* 내용 넣기 */}
             <SRateInfo>
               <div className="rateExplain">
                 이 책에 대한 평점과 리뷰를 남겨보세요
@@ -136,15 +124,7 @@ const RateModal = ({ isModalOpen, handleCloseModal, data }) => {
                   placeholder="리뷰를 입력해주세요"
                   onChange={handleChangeRateContent}
                 ></textarea>
-                {content.length < 1 ? (
-                  <SLimitNumber>1글자 이상 입력하십시오</SLimitNumber>
-                ) : null}
-                <button
-                  className="rateReviewBtn"
-                  onClick={handleClickRateSubmit}
-                >
-                  리뷰 남기기
-                </button>
+                <Button text="리뷰 남기기" onClick={handleRateSubmit} wide />
               </div>
             </SRateInfo>
           </SRateModal>

--- a/client/src/components/rate/RateModal.js
+++ b/client/src/components/rate/RateModal.js
@@ -67,40 +67,39 @@ const RateModal = ({ isModalOpen, handleCloseModal, data }) => {
   };
 
   const handleRateSubmit = () => {
-    // 로그인 회원만 이용가능한 서비스
-    // TODO: 로직 리팩토링
     const sessionAccessToken = sessionStorage.getItem('accessToken');
-    if (sessionAccessToken) {
-      if (content.length === 0) {
-        showWarningAlert(
-          '내용을 입력하세요',
-          '최소 1글자 이상 작성해야 합니다'
-        );
-      } else {
-        instanceAxios
-          .post(
-            `/v1/rates?isbn=${data.isbn}&bookTitle=${data.bookTitle}&author=${data.author}&publisher=${data.publisher}`,
-            {
-              rating,
-              content,
-            }
-          )
-          .then((res) => {
-            handleCloseModal();
-            window.location.reload();
-          })
-          .catch((err) => {
-            console.error(err);
-            showWarningAlert(
-              '이미 등록한 평점이 존재합니다',
-              '평점은 한 번만 등록할 수 있습니다'
-            );
-            handleCloseModal();
-          });
-      }
-    } else {
+
+    // 로그인 회원만 이용가능한 서비스
+    if (!sessionAccessToken) {
       showRequireLogin();
+      return;
     }
+
+    if (content.length === 0) {
+      showWarningAlert('내용을 입력하세요', '최소 1글자 이상 작성해야 합니다');
+      return;
+    }
+
+    instanceAxios
+      .post(
+        `/v1/rates?isbn=${data.isbn}&bookTitle=${data.bookTitle}&author=${data.author}&publisher=${data.publisher}`,
+        {
+          rating,
+          content,
+        }
+      )
+      .then((res) => {
+        handleCloseModal();
+        window.location.reload();
+      })
+      .catch((err) => {
+        console.error(err);
+        showWarningAlert(
+          '이미 등록한 평점이 존재합니다',
+          '평점은 한 번만 등록할 수 있습니다'
+        );
+        handleCloseModal();
+      });
   };
 
   return (

--- a/client/src/components/rate/RateModal.js
+++ b/client/src/components/rate/RateModal.js
@@ -56,6 +56,9 @@ const SRateInfo = styled.div`
     height: 100px;
     width: 300px;
   }
+  button {
+    margin-top: 20px;
+  }
 `;
 
 const RateModal = ({ isModalOpen, handleCloseModal, data }) => {
@@ -123,7 +126,12 @@ const RateModal = ({ isModalOpen, handleCloseModal, data }) => {
                   placeholder="리뷰를 입력해주세요"
                   onChange={handleChangeRateContent}
                 ></textarea>
-                <Button text="리뷰 남기기" onClick={handleRateSubmit} wide />
+                <Button
+                  text="리뷰 남기기"
+                  onClick={handleRateSubmit}
+                  wide
+                  primary
+                />
               </div>
             </SRateInfo>
           </SRateModal>

--- a/client/src/components/request/ReqForm.js
+++ b/client/src/components/request/ReqForm.js
@@ -220,6 +220,7 @@ const ReqForm = (props) => {
         <Button
           text={props.page === 'reqAdd' ? '등록' : '수정'}
           onClick={props.onClick}
+          primary
         />
       </SButtonBox>
     </StyledReqForm>

--- a/client/src/components/request/ReqForm.js
+++ b/client/src/components/request/ReqForm.js
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import BookAddModal from '../common/BookAddModal';
+import { Button } from '../common/Button';
 import { showConfirmAlert } from '../common/Alert';
 
 const StyledReqForm = styled.div`
@@ -12,6 +13,7 @@ const StyledReqForm = styled.div`
     border-bottom: 1px solid #acacac;
   }
 `;
+
 const SInputContainer = styled.div`
   display: flex;
   justify-content: space-between;
@@ -92,24 +94,8 @@ const SButtonBox = styled.div`
   justify-content: center;
   margin-bottom: 70px;
   button {
-    width: 15%;
+    width: 15rem;
     height: 35px;
-    border: 1px solid #bb2649;
-    border-radius: 5px;
-  }
-  .cancelBtn {
-    color: #bb2649;
-    background-color: #ffffff;
-    border: 1px solid #bb2649;
-    margin-right: 5%;
-    :hover {
-    }
-  }
-  .submitBtn {
-    color: #ffffff;
-    background-color: #bb2649;
-    :hover {
-    }
   }
 `;
 
@@ -124,7 +110,7 @@ const ReqForm = (props) => {
     onBookInfoChange({ ...inputs, [`${type}`]: e.target.value });
   };
 
-  const goBack = () => {
+  const handleCancel = () => {
     showConfirmAlert({
       title: '작성을 취소하시겠습니까?',
       text: '작성 중인 내용은 저장되지 않습니다',
@@ -230,12 +216,11 @@ const ReqForm = (props) => {
         </SInputRight>
       </SInputContainer>
       <SButtonBox>
-        <button className="cancelBtn" onClick={goBack}>
-          취소
-        </button>
-        <button className="submitBtn" onClick={props.editBtn}>
-          {props.page === 'reqAdd' ? '요청' : '수정'}
-        </button>
+        <Button text="취소" onClick={handleCancel} cancel />
+        <Button
+          text={props.page === 'reqAdd' ? '등록' : '수정'}
+          onClick={props.onClick}
+        />
       </SButtonBox>
     </StyledReqForm>
   );

--- a/client/src/components/share/ShareForm.js
+++ b/client/src/components/share/ShareForm.js
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import BookAddModal from '../common/BookAddModal';
 import axios from 'axios';
 import { showWarningAlert, showConfirmAlert } from '../common/Alert';
+import { Button } from '../common/Button';
 
 const StyledShareForm = styled.div`
   .title {
@@ -18,7 +19,7 @@ const SInputContainer = styled.div`
   justify-content: space-between;
   margin: 30px 11% 10px 14%;
   font-size: 13px;
-  #ImgInput {
+  #imgInput {
     display: none;
   }
   @media screen and (max-width: 1070px) {
@@ -58,33 +59,26 @@ const SImgBtn = styled.div`
   text-align: center;
   justify-content: center;
   margin-bottom: 20px;
-  .ImgInputBtn {
+  .imgInputBtn {
     width: 100px;
     height: 30px;
-    margin-right: 5px;
-    border: 1px solid #d0c9c0;
     border-radius: 4px;
+    border: 1px solid #d0c9c0;
+    margin-right: 5px;
     background-color: #d0c9c0;
     display: flex;
     align-items: center;
     justify-content: center;
     font-weight: 700;
-    :hover {
-      cursor: pointer;
-    }
   }
 
   .imgDelete {
     width: 100px;
     height: 30px;
-    border: 1px solid #d0c9c0;
     border-radius: 4px;
+    border: 1px solid #d0c9c0;
     background-color: #d0c9c0;
-    text-align: center;
     font-weight: 700;
-    :hover {
-      cursor: pointer;
-    }
   }
 `;
 
@@ -123,22 +117,6 @@ const SButtonBox = styled.div`
   button {
     width: 15%;
     height: 35px;
-    border: 1px solid #bb2649;
-    border-radius: 5px;
-  }
-  .cancelBtn {
-    color: #bb2649;
-    background-color: #ffffff;
-    border: 1px solid #bb2649;
-    margin-right: 5%;
-    :hover {
-    }
-  }
-  .submitBtn {
-    color: #ffffff;
-    background-color: #bb2649;
-    :hover {
-    }
   }
 `;
 
@@ -192,7 +170,7 @@ const ShareForm = (props) => {
     }
   };
 
-  const goBack = () => {
+  const handleCancel = () => {
     showConfirmAlert({
       title: '작성을 취소하시겠습니까?',
       text: '작성 중인 내용은 저장되지 않습니다',
@@ -236,11 +214,11 @@ const ShareForm = (props) => {
             <input
               type="file"
               accept="image/*"
-              id="ImgInput"
+              id="imgInput"
               disabled={bookTitle === undefined || bookTitle === ''}
               onChange={uploadImg}
             />
-            <label className="ImgInputBtn" htmlFor="ImgInput">
+            <label className="imgInputBtn" htmlFor="imgInput">
               책 표지 등록
             </label>
             <button className="imgDelete" onClick={() => deleteImg()}>
@@ -319,12 +297,11 @@ const ShareForm = (props) => {
         </SInputRight>
       </SInputContainer>
       <SButtonBox>
-        <button className="cancelBtn" onClick={goBack}>
-          취소
-        </button>
-        <button className="submitBtn" onClick={props.editBtn}>
-          {props.page === 'shareAdd' ? '등록' : '수정'}
-        </button>
+        <Button text="취소" onClick={handleCancel} cancel />
+        <Button
+          text={props.page === 'shareAdd' ? '등록' : '수정'}
+          onClick={props.onClick}
+        />
       </SButtonBox>
     </StyledShareForm>
   );

--- a/client/src/pages/RateAdd.js
+++ b/client/src/pages/RateAdd.js
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import BookAddModal from '../components/common/BookAddModal';
+import { Button } from '../components/common/Button';
 import instanceAxios from '../util/InstanceAxios';
 import { RateStar } from '../components/rate/RateStar';
 import {
@@ -87,24 +88,8 @@ const SButtonBox = styled.div`
   justify-content: center;
   margin-bottom: 70px;
   button {
-    width: 15%;
+    width: 15rem;
     height: 35px;
-    border: 1px solid #bb2649;
-    border-radius: 5px;
-  }
-  .cancelBtn {
-    color: #bb2649;
-    background-color: #ffffff;
-    border: 1px solid #bb2649;
-    margin-right: 5%;
-    :hover {
-    }
-  }
-  .submitBtn {
-    color: #ffffff;
-    background-color: #bb2649;
-    :hover {
-    }
   }
 `;
 
@@ -235,12 +220,8 @@ const RateAdd = () => {
         </SInputs>
       </SInputContainer>
       <SButtonBox>
-        <button className="cancelBtn" onClick={handleCancel}>
-          취소
-        </button>
-        <button className="submitBtn" onClick={handleSubmit}>
-          등록
-        </button>
+        <Button text="취소" onClick={handleCancel} cancel />
+        <Button text="등록" onClick={handleSubmit} />
       </SButtonBox>
     </StyledForm>
   );

--- a/client/src/pages/RateList.js
+++ b/client/src/pages/RateList.js
@@ -5,6 +5,7 @@ import RateItems from '../components/rate/RateItems';
 import { useNavigate } from 'react-router-dom';
 import Paging from '../components/common/Paging';
 import Loading from '../components/common/Loading';
+import { RegisterButton } from '../components/common/Button';
 
 const StyledRateList = styled.div`
   margin: 0 190px;
@@ -37,32 +38,6 @@ const StyledRateList = styled.div`
         @media screen and (max-width: 555px) {
           display: none;
         }
-      }
-    }
-    .rateBtn {
-      width: 100px;
-      height: 38px;
-      padding: 10px;
-      border: 1px solid #bb2649;
-      border-radius: 3px;
-      color: #ffffff;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      background-color: #cf385b;
-      box-shadow: inset 0 1px 0 hsla(0, 0%, 100%, 0.7);
-      font-weight: 500;
-
-      :hover {
-        color: #ffffff;
-        background-color: #bb2649;
-        border: 1px solid #bb2649;
-      }
-      @media screen and (max-width: 1023px) {
-        font-size: 16px;
-        width: 90px;
-        height: 41px;
-        padding: 0;
       }
     }
   }
@@ -117,11 +92,11 @@ const RateList = (props) => {
           <h2>빌리지 사람들의 평점 목록입니다!</h2>
           <p>알고 있는 책에 자유롭게 평점을 매겨보세요!</p>
         </div>
-        <div>
-          <button className="rateBtn" onClick={() => navigate('/rateAdd')}>
-            책 등록하기
-          </button>
-        </div>
+        <RegisterButton
+          rate
+          text="책 등록하기"
+          onClick={() => navigate('/rateAdd')}
+        />
       </div>
       {isLoading ? <Loading /> : <RateItems data={bookItems} />}
       <Paging

--- a/client/src/pages/RateList.js
+++ b/client/src/pages/RateList.js
@@ -21,12 +21,6 @@ const StyledRateList = styled.div`
     display: flex;
     justify-content: space-between;
     align-items: center;
-    @media screen and (max-width: 555px) {
-      display: flex;
-      flex-direction: column;
-      font-size: 14px;
-      height: 150px;
-    }
     .title {
       display: flex;
       flex-direction: column;
@@ -34,10 +28,14 @@ const StyledRateList = styled.div`
         margin-bottom: 0;
         font-size: 22px;
       }
+    }
+    @media screen and (max-width: 555px) {
+      display: flex;
+      flex-direction: column;
+      font-size: 14px;
+      height: 150px;
       p {
-        @media screen and (max-width: 555px) {
-          display: none;
-        }
+        display: none;
       }
     }
   }
@@ -93,9 +91,10 @@ const RateList = (props) => {
           <p>알고 있는 책에 자유롭게 평점을 매겨보세요!</p>
         </div>
         <RegisterButton
-          rate
           text="책 등록하기"
           onClick={() => navigate('/rateAdd')}
+          rate
+          primary
         />
       </div>
       {isLoading ? <Loading /> : <RateItems data={bookItems} />}

--- a/client/src/pages/ReqAdd.js
+++ b/client/src/pages/ReqAdd.js
@@ -71,7 +71,7 @@ const ReqAdd = () => {
   return (
     <ReqForm
       page="reqAdd"
-      editBtn={handleClickSubmit}
+      onClick={handleClickSubmit}
       inputs={inputs}
       onBookInfoChange={handleBookInfoChange}
     ></ReqForm>

--- a/client/src/pages/ReqEdit.js
+++ b/client/src/pages/ReqEdit.js
@@ -66,7 +66,7 @@ const ReqEdit = () => {
   return (
     <ReqForm
       page="ReqEdit"
-      editBtn={handleClickSubmit}
+      onClick={handleClickSubmit}
       inputs={inputs}
       onBookInfoChange={handleBookInfoChange}
     />

--- a/client/src/pages/ShareAdd.js
+++ b/client/src/pages/ShareAdd.js
@@ -71,7 +71,7 @@ const ShareAdd = () => {
     <>
       <ShareForm
         page="shareAdd"
-        editBtn={handleClickSubmit}
+        onClick={handleClickSubmit}
         inputs={inputs}
         onBookInfoChange={handleBookInfoChange}
       />

--- a/client/src/pages/ShareEdit.js
+++ b/client/src/pages/ShareEdit.js
@@ -65,7 +65,7 @@ const ShareEdit = (onBookInfoChange) => {
     <>
       <ShareForm
         page="shareEdit"
-        editBtn={handleClickEdit}
+        onClick={handleClickEdit}
         inputs={inputs}
         onBookInfoChange={handleBookInfoChange}
       />


### PR DESCRIPTION
### 작업한 내용
- 곳곳에 쓰인 버튼을 한 컴포넌트 파일에서 관리하도록 분리
- `styled-components`의 `css` helper 활용
- 비슷한 스타일의 컴포넌트가 여러 파일에서 반복되는 경우 파일로 분리
- 한 페이지/컴포넌트에서 여러 스타일로 분리될 때는 `styled-components`의 상속을 이용
- 글 등록 토큰 확인 `if/else` 로직 가독성 좋게 수정
- 일부 대문자로 작성된 클래스네임 소문자로 수정

### 보충할 내용
- 
